### PR TITLE
Fix URL field of version file

### DIFF
--- a/GameData/SpaceProgramFunding/SpaceProgramFunding.version
+++ b/GameData/SpaceProgramFunding/SpaceProgramFunding.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Space Program Funding",
-  "URL": "https://github.com/JoeBostic/SpaceProgramFunding/wiki",
+  "URL": "https://raw.githubusercontent.com/JoeBostic/SpaceProgramFunding/master/GameData/SpaceProgramFunding/SpaceProgramFunding.version",
   "DOWNLOAD": "https://github.com/JoeBostic/SpaceProgramFunding/releases",
   "GITHUB": {
     "USERNAME": "JoeBostic",


### PR DESCRIPTION
This field is meant to point to a copy of this file available online so the plugin can check for updates.

http://ksp.cybutek.net/kspavc/Documents/README.htm

> - **URL** - Optional
>   Location of a remote version file for update checking.

Noted while reviewing KSP-CKAN/NetKAN#7367.